### PR TITLE
Reduce startup CPU spikes by adding serial timeouts and avoiding busy spin

### DIFF
--- a/airaflot_waterdrone/airaflot_waterdrone/peripheral_modules/echo_sounder/echo_sounder.py
+++ b/airaflot_waterdrone/airaflot_waterdrone/peripheral_modules/echo_sounder/echo_sounder.py
@@ -39,7 +39,7 @@ class EchoSounder(LifecycleNode):
             if port is None:
                 return TransitionCallbackReturn.FAILURE
 
-            self.serial : serial.Serial | None = serial.Serial(port, 115200)
+            self.serial : serial.Serial | None = serial.Serial(port, 115200, timeout=0.1)
             self.publisher = self.create_lifecycle_publisher(
                 NMEADBT, ECHOSOUNDER_DATA_TOPIC, 10
             )
@@ -97,7 +97,7 @@ class EchoSounder(LifecycleNode):
         self.logger.info(f"Available ports: {port_names}")
         for port in port_names:
             self.logger.info(f"Check port: {port}")
-            ser = serial.Serial(port, 115200)
+            ser = serial.Serial(port, 115200, timeout=0.1)
             time.sleep(0.5)
             ser.write(INFO_COMMAND)
             time.sleep(0.5)

--- a/airaflot_waterdrone/airaflot_waterdrone/peripheral_modules/gps_external/gps_external.py
+++ b/airaflot_waterdrone/airaflot_waterdrone/peripheral_modules/gps_external/gps_external.py
@@ -37,7 +37,7 @@ class GPSExternalNode(LifecycleNode):
             if port is None:
                 return TransitionCallbackReturn.FAILURE
 
-            self.serial : serial.Serial | None = serial.Serial(port, 115200)
+            self.serial : serial.Serial | None = serial.Serial(port, 115200, timeout=0.1)
             self.publisher = self.create_lifecycle_publisher(
                 NMEAGPGGA, GPS_EXTERNAL_DATA_TOPIC_NAME, 10
             )
@@ -108,7 +108,7 @@ class GPSExternalNode(LifecycleNode):
         self.logger.info(f"Available ports: {port_names}")
         for port in port_names:
             self.logger.info(f"Check port: {port}")
-            ser = serial.Serial(port, 115200)
+            ser = serial.Serial(port, 115200, timeout=0.1)
             time.sleep(0.5)
             ser.write("log com1 gpgga once\r\n".encode("ascii"))
             time.sleep(0.5)

--- a/airaflot_waterdrone/airaflot_waterdrone/senders/common_sender.py
+++ b/airaflot_waterdrone/airaflot_waterdrone/senders/common_sender.py
@@ -75,7 +75,7 @@ class CommonSender(LifecycleNode):
                 if not_sent_path.exists():
                     if any(not_sent_path.iterdir()):
                         for filepath in not_sent_path.iterdir():
-                            rclpy.spin_once(self, timeout_sec=0)
+                            rclpy.spin_once(self, timeout_sec=0.05)
                             if self._file_created_long_ago(filepath):
                                 if self._send_data_from_file(filepath):
                                     self._move_to_sent(filepath)


### PR DESCRIPTION
## Summary
- prevent busy-wait by spinning with a small timeout in common sender
- make GPS and echo sounder serial ports blocking with 100ms timeout

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'ament_copyright')*


------
https://chatgpt.com/codex/tasks/task_e_68a2e4b0d9ec832db43d5e4f8a7a3ba0